### PR TITLE
release: v2026.6.11

### DIFF
--- a/BrainX/__init__.py
+++ b/BrainX/__init__.py
@@ -16,5 +16,5 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "2026.6.8"
+__version__ = "2026.6.11"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 
 
 
+## v2026.6.11
+
+This maintenance release refreshes the pinned infrastructure component versions.
+
+- **Package Dependencies:**
+  - [`brainunit==0.4.0`](https://pypi.org/project/brainunit/0.4.0/) ↗️
+  - [`brainstate==0.4.2`](https://pypi.org/project/brainstate/0.4.2/) ↗️
+  - [`braintools==0.1.10`](https://pypi.org/project/braintools/0.1.10/) ↗️
+  - [`brainevent==0.1.0`](https://pypi.org/project/brainevent/0.1.0/)
+  - [`braintrace==0.2.0`](https://pypi.org/project/braintrace/0.2.0/)
+  - [`braincell==0.0.8`](https://pypi.org/project/braincell/0.0.8/)
+  - [`brainpy==2.7.8`](https://pypi.org/project/brainpy/2.7.8/)
+  - [`brainpy-state==0.0.4`](https://pypi.org/project/brainpy-state/0.0.4/)
+  - [`brainmass==0.0.5`](https://pypi.org/project/brainmass/0.0.5/)
+  - [`pinnx==0.0.3`](https://pypi.org/project/pinnx/0.0.3/)
+
+
 
 ## v2026.6.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # infrastructure packages
-brainunit==0.3.2
+brainunit==0.4.0
 brainevent==0.1.0
-brainstate==0.4.0
-braintools==0.1.9
+brainstate==0.4.2
+braintools==0.1.10
 braintrace==0.2.0
 
 # modeling packages


### PR DESCRIPTION
## Release v2026.6.11

Maintenance release refreshing the pinned BrainX infrastructure component versions.

### Updated dependencies
- `brainunit` 0.3.2 → **0.4.0**
- `brainstate` 0.4.0 → **0.4.2**
- `braintools` 0.1.9 → **0.1.10**

### Changes
- Bump `__version__` to `2026.6.11`.
- Update `requirements.txt` pins for the three infrastructure packages above.
- Add the `v2026.6.11` entry to `CHANGELOG.md`.
