### PR TITLE
release: v2026.6.14

### DIFF
--- a/BrainX/__init__.py
+++ b/BrainX/__init__.py
@@ -16,5 +16,5 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "2026.6.11"
+__version__ = "2026.6.14"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 
 
+## v2026.6.14
+
+This maintenance release upgrades BrainState to its 0.5.0 release.
+
+- **Package Dependencies:**
+  - [`brainstate==0.5.0`](https://pypi.org/project/brainstate/0.5.0/) ↗️
+  - [`brainunit==0.4.0`](https://pypi.org/project/brainunit/0.4.0/)
+  - [`braintools==0.1.10`](https://pypi.org/project/braintools/0.1.10/)
+  - [`brainevent==0.1.0`](https://pypi.org/project/brainevent/0.1.0/)
+  - [`braintrace==0.2.0`](https://pypi.org/project/braintrace/0.2.0/)
+  - [`braincell==0.0.8`](https://pypi.org/project/braincell/0.0.8/)
+  - [`brainpy==2.7.8`](https://pypi.org/project/brainpy/2.7.8/)
+  - [`brainpy-state==0.0.4`](https://pypi.org/project/brainpy-state/0.0.4/)
+  - [`brainmass==0.0.5`](https://pypi.org/project/brainmass/0.0.5/)
+  - [`pinnx==0.0.3`](https://pypi.org/project/pinnx/0.0.3/)
+
+
+
 ## v2026.6.11
 
 This maintenance release refreshes the pinned infrastructure component versions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # infrastructure packages
 brainunit==0.4.0
 brainevent==0.1.0
-brainstate==0.4.2
+brainstate==0.5.0
 braintools==0.1.10
 braintrace==0.2.0
 


### PR DESCRIPTION
This maintenance release upgrades BrainState to its 0.5.0 release.

- **Package Dependencies:**
  - [`brainstate==0.5.0`](https://pypi.org/project/brainstate/0.5.0/) ↗️ (was `0.4.2`)
  - [`brainunit==0.4.0`](https://pypi.org/project/brainunit/0.4.0/)
  - [`braintools==0.1.10`](https://pypi.org/project/braintools/0.1.10/)
  - [`brainevent==0.1.0`](https://pypi.org/project/brainevent/0.1.0/)
  - [`braintrace==0.2.0`](https://pypi.org/project/braintrace/0.2.0/)
  - [`braincell==0.0.8`](https://pypi.org/project/braincell/0.0.8/)
  - [`brainpy==2.7.8`](https://pypi.org/project/brainpy/2.7.8/)
  - [`brainpy-state==0.0.4`](https://pypi.org/project/brainpy-state/0.0.4/)
  - [`brainmass==0.0.5`](https://pypi.org/project/brainmass/0.0.5/)
  - [`pinnx==0.0.3`](https://pypi.org/project/pinnx/0.0.3/)

## Summary by Sourcery

Prepare the 2026.6.14 maintenance release with an updated BrainState dependency and version metadata.

Build:
- Update Python package requirement to depend on brainstate 0.5.0 instead of 0.4.2.

Chores:
- Bump library version to 2026.6.14 and document the release and dependency set in the changelog.