### PR TITLE
release: v2026.6.18

### DIFF
--- a/BrainX/__init__.py
+++ b/BrainX/__init__.py
@@ -16,5 +16,5 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = "2026.6.14"
+__version__ = "2026.6.18"
 __version_info__ = tuple(map(int, __version__.split(".")))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@
 
 
 
+## v2026.6.18
+
+This maintenance release upgrades BrainPy-State to its 0.1.0 release.
+
+- **Package Dependencies:**
+  - [`brainstate==0.5.0`](https://pypi.org/project/brainstate/0.5.0/)
+  - [`brainunit==0.4.0`](https://pypi.org/project/brainunit/0.4.0/)
+  - [`braintools==0.1.10`](https://pypi.org/project/braintools/0.1.10/)
+  - [`brainevent==0.1.0`](https://pypi.org/project/brainevent/0.1.0/)
+  - [`braintrace==0.2.0`](https://pypi.org/project/braintrace/0.2.0/)
+  - [`braincell==0.0.8`](https://pypi.org/project/braincell/0.0.8/)
+  - [`brainpy==2.7.8`](https://pypi.org/project/brainpy/2.7.8/)
+  - [`brainpy-state==0.1.0`](https://pypi.org/project/brainpy-state/0.1.0/) ↗️
+  - [`brainmass==0.0.5`](https://pypi.org/project/brainmass/0.0.5/)
+  - [`pinnx==0.0.3`](https://pypi.org/project/pinnx/0.0.3/)
+
+
+
 ## v2026.6.14
 
 This maintenance release upgrades BrainState to its 0.5.0 release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ braintrace==0.2.0
 # modeling packages
 braincell==0.0.8
 brainpy==2.7.8
-brainpy-state==0.0.4
+brainpy-state==0.1.0
 brainmass==0.0.5
 pinnx==0.0.3
 


### PR DESCRIPTION
## Summary

Maintenance release **v2026.6.18**. Upgrades the pinned **BrainPy-State** component to its `0.1.0` release and bumps the package version accordingly.

## Changes

- **Version:** `BrainX.__version__` `2026.6.14` → `2026.6.18`
- **Dependencies:** `brainpy-state` `0.0.4` → [`0.1.0`](https://pypi.org/project/brainpy-state/0.1.0/) (all other pinned components unchanged)
- **Changelog:** added the `v2026.6.18` entry to `CHANGELOG.md`

## Notes

PyPI publishing is handled automatically by trusted publishing on GitHub release.

## Summary by Sourcery

Prepare maintenance release v2026.6.18 by updating the package version, upgrading the pinned BrainPy-State dependency to 0.1.0, and documenting the changes in the changelog.

Enhancements:
- Bump BrainPy-State dependency from 0.0.4 to 0.1.0 while keeping other pinned components unchanged.

Build:
- Update BrainX package version to 2026.6.18.

Documentation:
- Add CHANGELOG entry documenting the v2026.6.18 maintenance release and updated dependency versions.