### PR TITLE
Release 2026.6.29: refresh brainstate 0.5.2 & braintrace 0.2.2, drop pinnx, add cross-package compatibility tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,9 @@ jobs:
           python -m pip install --upgrade pip setuptools --no-cache-dir
           python -m pip install -r requirements.txt --no-cache-dir
           python -m pip install pytest --no-cache-dir
-          python -m pip install . --no-cache-dir
+          # Install the CPU extra so brainevent's numba-backed event/sparse
+          # kernels are available to the cross-package compatibility tests.
+          python -m pip install ".[cpu]" --no-cache-dir
       - name: Test with pytest
         run: |
           pytest BrainX/
@@ -78,12 +80,14 @@ jobs:
           python -m pip install --upgrade pip setuptools
           python -m pip install -r requirements.txt
           python -m pip install pytest
+          # Install the CPU extra (numba + jax[cpu]) first, then pin the matrix
+          # JAX version last so it wins over the extra's resolved jax.
+          python -m pip install ".[cpu]" || exit 1
           if [ "${{ matrix.jax-version }}" == "" ]; then
             python -m pip install jax || exit 1
           else
             python -m pip install jax==${{ matrix.jax-version }} || exit 1
           fi
-          python -m pip install . || exit 1
       - name: Test with pytest
         run: |
           pytest BrainX/

--- a/BrainX/compatibility_test.py
+++ b/BrainX/compatibility_test.py
@@ -1,0 +1,257 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# -*- coding: utf-8 -*-
+
+"""Cross-package compatibility and basic-correctness tests for the BrainX stack.
+
+Where ``version_test.py`` only checks that the pinned versions are coherent, this
+module exercises *interoperation*: the pinned ecosystem packages are imported
+together and driven through small, deterministic computations that cut across
+package boundaries (units in state + transforms, event/sparse operators, the
+``braintrace`` ↔ ``brainstate`` eligibility-trace path, neural-mass and
+single-compartment integration, …).
+
+The assertions are intentionally *hard* rather than skipped on error: the whole
+point of the suite is to surface a real incompatibility in the pinned set, so a
+genuine break must fail loudly. Numerical checks use exact discrete references or
+loose tolerances so they stay valid across the supported JAX-version matrix.
+
+All repeated dynamics are driven with ``brainstate.transform`` primitives
+(``for_loop`` / ``jit``), never bare Python loops.
+"""
+
+import re
+
+import jax.numpy as jnp
+import numpy as np
+
+import brainstate
+import brainunit as u
+
+
+def _version_tuple(text):
+    """Parse a leading ``MAJOR.MINOR.PATCH`` into a comparable int tuple."""
+    parts = re.findall(r"\d+", text)
+    return tuple(int(p) for p in parts[:3])
+
+
+# ---------------------------------------------------------------------------
+# Version coherence — the coupled brainstate>=0.5.2 / braintrace>=0.2.2 contract.
+# ---------------------------------------------------------------------------
+
+def test_coupled_versions_are_coherent():
+    """braintrace 0.2.2 requires brainstate>=0.5.2; the pins must reflect that."""
+    import braintrace
+
+    assert _version_tuple(brainstate.__version__) >= (0, 5, 2), brainstate.__version__
+    assert _version_tuple(braintrace.__version__) >= (0, 2, 2), braintrace.__version__
+
+
+def test_new_feature_contract_present():
+    """The APIs that couple the two bumps are importable/callable."""
+    import braintrace
+
+    # Added in brainstate 0.5.2 — the probe predicate braintrace.compile relies on.
+    assert hasattr(brainstate.transform, "in_new_state_probe")
+    assert callable(brainstate.transform.in_new_state_probe)
+    # The unified entry point introduced/cemented in braintrace 0.2.2.
+    assert callable(braintrace.compile)
+
+
+# ---------------------------------------------------------------------------
+# brainunit ↔ brainstate — unit-carrying State integrated by a transform.
+# ---------------------------------------------------------------------------
+
+def test_brainunit_state_decay_under_for_loop():
+    """A unit-aware State decays correctly under ``transform.for_loop``.
+
+    Forward-Euler ``dV = -V/tau * dt`` for ``n`` steps has the exact closed form
+    ``V0 * (1 - dt/tau)**n``; with ``T = n*dt = tau`` it also approximates the
+    continuous ``V0 * exp(-1)``. Both the magnitude and the ``mV`` unit must
+    survive the transform.
+    """
+    tau, dt, v0, n = 10.0 * u.ms, 0.1 * u.ms, 1.0 * u.mV, 100
+    v = brainstate.HiddenState(v0)
+
+    def step(_):
+        v.value = v.value - v.value / tau * dt
+        return v.value
+
+    brainstate.transform.for_loop(step, np.arange(n))
+    final = v.value
+
+    ratio = float(dt / tau)  # dimensionless 0.01
+    exact = v0 * (1.0 - ratio) ** n
+    assert u.math.allclose(final, exact, rtol=1e-4), (final, exact)
+
+    # ``to_decimal(mV)`` raises unless ``final`` is voltage-dimensioned, so this
+    # both checks the value and pins the unit.
+    final_mv = final.to_decimal(u.mV)
+    assert abs(final_mv - float(np.exp(-1))) < 0.05, final_mv
+
+
+# ---------------------------------------------------------------------------
+# brainevent — event-driven / sparse operators agree with dense references.
+# ---------------------------------------------------------------------------
+
+def test_brainevent_binary_matmul_matches_dense():
+    """A spike (binary) vector through brainevent equals the dense matmul.
+
+    brainevent's CPU event/sparse kernels are generated with numba, which the
+    test environment provides via the ``brainx[cpu]`` extra.
+    """
+    import brainevent
+
+    spikes = jnp.asarray([1, 0, 1, 0, 1], dtype=bool)
+    weight = jnp.asarray(np.random.RandomState(0).rand(5, 3))
+
+    out = jnp.asarray(brainevent.BinaryArray(spikes) @ weight)
+    ref = spikes.astype(weight.dtype) @ weight
+    assert out.shape == (3,)
+    assert jnp.allclose(out, ref), (out, ref)
+
+
+def test_brainevent_csr_matches_dense():
+    """A brainevent CSR matrix-vector product equals its dense reference."""
+    import brainevent
+
+    dense = jnp.asarray(np.random.RandomState(1).rand(4, 5))
+    vector = jnp.asarray(np.random.RandomState(2).rand(5))
+
+    csr = brainevent.CSR.fromdense(dense)
+    assert jnp.allclose(jnp.asarray(csr @ vector), dense @ vector)
+
+
+# ---------------------------------------------------------------------------
+# braintools ↔ brainstate — initializers, metrics, and an nn layer.
+# ---------------------------------------------------------------------------
+
+def test_braintools_init_and_metric_are_correct():
+    """A deterministic initializer and metric give exactly the expected values."""
+    import braintools
+
+    weight = braintools.init.Constant(0.5)([2, 3])
+    assert weight.shape == (2, 3)
+    assert jnp.allclose(jnp.asarray(weight), 0.5)
+
+    pred = jnp.asarray([1.0, 2.0, 3.0])
+    target = jnp.asarray([1.0, 2.0, 5.0])
+    # |pred - target| = [0, 0, 2]  ->  mean 2/3.
+    mae = float(jnp.mean(jnp.asarray(braintools.metric.absolute_error(pred, target))))
+    assert abs(mae - 2.0 / 3.0) < 1e-6, mae
+
+
+def test_brainstate_nn_linear_forward():
+    """A ``brainstate.nn`` layer runs and produces a finite, correctly shaped output."""
+    layer = brainstate.nn.Linear(4, 3)
+    out = layer(jnp.ones((2, 4)))
+    assert out.shape == (2, 3)
+    assert bool(jnp.all(jnp.isfinite(out)))
+
+
+# ---------------------------------------------------------------------------
+# brainpy.state — a point neuron steps under a dt context (reuses brainstate).
+# ---------------------------------------------------------------------------
+
+def test_brainpy_state_neuron_step():
+    """A ``brainpy.state`` LIF neuron initialises and advances one finite step."""
+    import brainpy.state as bp_state
+
+    with brainstate.environ.context(dt=0.1 * u.ms):
+        neuron = bp_state.LIF(5)
+        brainstate.nn.init_all_states(neuron)
+        out = neuron(jnp.ones(5) * u.mA)
+
+    assert jnp.asarray(out).shape == (5,)
+    assert bool(jnp.all(jnp.isfinite(jnp.asarray(out))))
+
+
+# ---------------------------------------------------------------------------
+# braincell — a single compartment integrates to a finite membrane voltage.
+# ---------------------------------------------------------------------------
+
+def test_braincell_single_compartment_integration():
+    """A ``braincell.SingleCompartment`` integrates stably under ``for_loop``.
+
+    Driving a default compartment with a constant current *density* and stepping
+    it through ``brainstate.transform.for_loop`` must leave the membrane voltage
+    finite and in millivolts (exercising braincell ↔ brainstate ↔ brainunit).
+    """
+    import braincell
+
+    with brainstate.environ.context(dt=0.01 * u.ms):
+        cell = braincell.SingleCompartment(size=1)
+        brainstate.nn.init_all_states(cell)
+
+        def step(_):
+            cell.update(1.0 * u.uA / u.cm ** 2)
+            return cell.V.value
+
+        voltages = brainstate.transform.for_loop(step, np.arange(50))
+
+    millivolts = voltages.to_decimal(u.mV)  # raises unless mV-dimensioned
+    assert millivolts.shape == (50, 1)
+    assert bool(jnp.all(jnp.isfinite(millivolts)))
+
+
+# ---------------------------------------------------------------------------
+# brainmass — a neural-mass model simulates to a finite trajectory.
+# ---------------------------------------------------------------------------
+
+def test_brainmass_meanfield_run():
+    """A ``brainmass`` mean-field node runs through the Simulator to finite output."""
+    import brainmass
+
+    assert len(brainmass.list_models()) == 20
+
+    node = brainmass.HopfStep(2, a=-0.2)
+    sim = brainmass.Simulator(node, dt=0.1 * u.ms)
+    result = sim.run(10.0 * u.ms, monitors=["x"])
+
+    trajectory = np.asarray(result["x"])
+    assert trajectory.shape == (100, 2)
+    assert np.all(np.isfinite(trajectory))
+
+
+# ---------------------------------------------------------------------------
+# braintrace ↔ brainstate — the eligibility-trace compile path (headline interop).
+# ---------------------------------------------------------------------------
+
+def test_braintrace_compile_etrace_learner():
+    """``braintrace.compile`` builds and runs a tiny online learner on brainstate.
+
+    This exercises the probe-deferral path: ``compile`` runs the eager
+    ``vmap_new_states`` discovery probe (whose cooperation predicate,
+    ``in_new_state_probe``, is the brainstate 0.5.2 feature) before producing the
+    real eligibility-trace algorithm.
+    """
+    import braintrace
+
+    class SimpleGRU(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec, n_out):
+            super().__init__()
+            self.rnn = braintrace.nn.GRUCell(n_in, n_rec)
+            self.out = braintrace.nn.Linear(n_rec, n_out)
+
+        def update(self, x):
+            return self.out(self.rnn(x))
+
+    model = SimpleGRU(8, 16, 4)
+    learner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(8))
+
+    out = learner(jnp.ones(8))
+    assert jnp.asarray(out).shape == (4,)
+    assert bool(jnp.all(jnp.isfinite(jnp.asarray(out))))

--- a/BrainX/version_test.py
+++ b/BrainX/version_test.py
@@ -24,8 +24,8 @@ import pytest
 
 import BrainX
 
-# Repository root: BrainX/tests/test_version.py -> parents[2].
-_REQUIREMENTS = Path(__file__).resolve().parents[2] / "requirements.txt"
+# Repository root: BrainX/version_test.py -> parents[1].
+_REQUIREMENTS = Path(__file__).resolve().parents[1] / "requirements.txt"
 
 # Matches an exact pin, e.g. ``brainstate==0.5.1`` (ignores ``>=``/``<=`` ranges,
 # comments, blank lines, and any trailing environment markers).
@@ -57,22 +57,22 @@ class Test:
         import brainpy.state
         import braincell
         import braintools
+        import braintrace
         import brainevent
         import brainunit
         import brainstate
-        import pinnx
 
         print(brainmass.__version__)
         print(brainpy.__version__)
         print(braincell.__version__)
         print(braintools.__version__)
+        print(braintrace.__version__)
         print(brainevent.__version__)
         print(brainunit.__version__)
         print(brainstate.__version__)
-        print(pinnx.__version__)
 
     def test_requirements_are_pinned(self):
-        """Every brain* / pinnx ecosystem package must be exactly pinned."""
+        """Every brain* ecosystem package must be exactly pinned."""
         expected = {
             "brainunit",
             "brainevent",
@@ -83,7 +83,6 @@ class Test:
             "brainpy",
             "brainpy-state",
             "brainmass",
-            "pinnx",
         }
         missing = sorted(expected - set(_PINNED))
         assert not missing, f"requirements.txt is missing exact pins for: {missing}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@
 
 
 
+## v2026.6.29
+
+This is a maintenance and refinement release. It refreshes two ecosystem
+components to their latest releases — **BrainState `0.5.2`** and **BrainTrace
+`0.2.2`** — slims the bundled dependency set by **removing `pinnx`**, and adds a
+cross-package **compatibility / correctness test suite** that exercises the pinned
+stack end-to-end. The two component bumps are *coupled*: BrainTrace `0.2.2`
+requires BrainState `>= 0.5.2`, and BrainState `0.5.2`'s new `in_new_state_probe()`
+is exactly the hook BrainTrace's unified `compile` path uses to cooperate with the
+eager state-discovery probe — so the pinned set stays mutually consistent.
+
+- **Package Dependencies:**
+  - [`jax<=0.10.2,>=0.8.0`](https://pypi.org/project/jax/)
+  - [`brainunit==0.5.1`](https://pypi.org/project/brainunit/0.5.1/)
+  - [`brainevent==0.1.1`](https://pypi.org/project/brainevent/0.1.1/)
+  - [`brainstate==0.5.2`](https://pypi.org/project/brainstate/0.5.2/) ↗️
+  - [`braintools==0.3.0`](https://pypi.org/project/braintools/0.3.0/)
+  - [`braintrace==0.2.2`](https://pypi.org/project/braintrace/0.2.2/) ↗️
+  - [`braincell==0.1.0`](https://pypi.org/project/braincell/0.1.0/)
+  - [`brainpy==2.8.0`](https://pypi.org/project/brainpy/2.8.0/)
+  - [`brainpy-state==0.1.0`](https://pypi.org/project/brainpy-state/0.1.0/)
+  - [`brainmass==0.1.1`](https://pypi.org/project/brainmass/0.1.1/)
+  - `pinnx` — **removed** from the bundled dependency set (see below)
+
+- **BrainState `0.5.2` — additive transform feature:**
+  - Adds `brainstate.transform.in_new_state_probe()`, a public predicate that lets
+    state-bound, one-shot consumers cooperate with the eager discovery probe that
+    `vmap_new_states` / `vmap2_new_states` / `pmap2_new_states` run to enumerate the
+    states a function creates before the real mapped pass
+  - Implemented as a thread-local depth counter, so it composes under nested
+    `*_new_states` calls and resets cleanly even if the probe raises
+  - No public API is removed or renamed, and behavior is unchanged for code that
+    does not call the new helper; 28 new regression tests, green on the JAX
+    `0.7`–latest matrix and the type-check gate
+
+- **BrainTrace `0.2.2` — unified online-learning entry point and vmap fixes:**
+  - `braintrace.compile(model, algorithm, *example_inputs, ...)` is now the
+    canonical single call for building a compiled eligibility-trace learner — it
+    always initializes states, accepts `seed` / `verbose`, adds a `vmap=` option for
+    per-sample state initialization, and exposes a structured `CompilationReport`
+  - Adds a recurrent mixing mode to graph construction, broadening the set of cell
+    topologies the compiler can connect
+  - Fixes eligibility-trace convergence under `vmap` / `brainstate.mixin.Batching()`
+    by deferring compilation during the discovery probe (aligning convolutional and
+    element-wise traces), and routes `LoRA` through the ETP `lora_matmul` primitive
+    so its factors participate in trace learning
+  - Migrates unit handling from `saiunit` to `brainunit` (a re-export, so it is
+    drop-in), raises the `brainstate` floor to `>= 0.5.2`, targets Python 3.14, and
+    renames private modules (`_etrace_*` → `_*`); 1604 tests pass and the documented
+    0.2.x public API is unchanged
+
+- **Removed `pinnx` from the bundled set:**
+  - The default `brainx` install now scopes to the core brain-simulation stack;
+    [PINNx](https://github.com/chaobrain/pinnx) (physics-informed neural networks)
+    remains a fully supported, independently released ecosystem project and can
+    still be installed on its own with `pip install pinnx`
+
+- **Cross-package compatibility testing:**
+  - Adds `BrainX/compatibility_test.py`, a co-located suite that imports the pinned
+    packages together and drives small, deterministic computations across package
+    boundaries: a unit-carrying `brainstate` state integrated by
+    `transform.for_loop`, `brainevent` event/sparse operators checked against dense
+    references, `braintools` initializers/metrics, a `brainpy.state` neuron step, a
+    `braincell.SingleCompartment` integration, a `brainmass` mean-field run, and the
+    `braintrace.compile` eligibility-trace path on BrainState `0.5.2`
+  - Tests are now co-located beside the package in the suffix style: the legacy
+    `BrainX/tests/test_version.py` becomes `BrainX/version_test.py` (the `tests/`
+    folder is removed), it drops its `pinnx` import and pin and now also imports
+    `braintrace`, and `pyproject.toml` configures pytest to collect `*_test.py`
+
+
+
 ## v2026.6.19
 
 This is a landmark release: the **first fully integrated and compatibility-hardened

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,9 @@ BrainX = ["py.typed"]
 [tool.setuptools.dynamic]
 version = { attr = "BrainX._version.__version__" }
 dependencies = { file = ["requirements.txt"] }
+
+
+[tool.pytest.ini_options]
+# Tests are co-located beside the package using the suffix style (``*_test.py``),
+# so ``pytest BrainX/`` runs the whole ecosystem suite.
+python_files = ["*_test.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
 # infrastructure packages
 brainunit==0.5.1
 brainevent==0.1.1
-brainstate==0.5.1
+brainstate==0.5.2
 braintools==0.3.0
-braintrace==0.2.1
+braintrace==0.2.2
 
 # modeling packages
 braincell==0.1.0
 brainpy==2.8.0
 brainpy-state==0.1.0
 brainmass==0.1.1
-pinnx==0.0.3
 
 # dependencies
 numpy>=2.4.4


### PR DESCRIPTION
## Summary

Maintenance/refinement release for the BrainX umbrella package.

- **Dependencies** (`requirements.txt`): `brainstate` 0.5.1 → **0.5.2**, `braintrace` 0.2.1 → **0.2.2** (coupled — braintrace 0.2.2 requires brainstate ≥ 0.5.2), and **`pinnx` removed** from the bundled set. All other pins already latest.
- **New cross-package tests** (`BrainX/compatibility_test.py`): 11 co-located smoke + correctness checks across package boundaries — unit-carrying `brainstate` state integrated by `transform.for_loop` (vs analytic decay), `brainevent` event/sparse vs dense, `braintools` init/metric, `brainpy.state` neuron step, `braincell.SingleCompartment` integration, `brainmass` mean-field run, and the `braintrace.compile` eligibility-trace path on brainstate 0.5.2.
- **Test layout**: `BrainX/tests/test_version.py` → `BrainX/version_test.py` (suffix style; `tests/` folder removed; drops `pinnx`, adds `braintrace`). `pyproject.toml` collects `*_test.py`.
- **CHANGELOG.md**: new `v2026.6.29` entry documenting the above and the upstream sub-package changelogs.

## Verification

`pytest BrainX/` → **23 passed** locally (Python 3.13, jax 0.10.1) against the upgraded set (`brainstate==0.5.2`, `braintrace==0.2.2`).

## Summary by Sourcery

Refresh BrainX dependency pins to the latest brainstate/braintrace versions, remove pinnx from the bundled stack, and add an end-to-end cross-package compatibility test suite with co-located tests.

New Features:
- Introduce a cross-package compatibility and correctness suite that exercises deterministic computations across all pinned BrainX ecosystem packages.

Enhancements:
- Align BrainX with brainstate 0.5.2 and braintrace 0.2.2, ensuring their coupled APIs and version constraints are coherent.
- Simplify the bundled dependency scope by dropping pinnx from requirements and import/version tests.
- Co-locate tests beside the BrainX package using *_test.py naming and configure pytest discovery accordingly.

Documentation:
- Add a v2026.6.29 changelog entry describing dependency updates, removal of pinnx, and the new compatibility test suite.

Tests:
- Add BrainX/compatibility_test.py with smoke and correctness checks spanning brainstate, braintrace, brainevent, braintools, brainpy.state, braincell, and brainmass.
- Update the version test to reflect the new layout, dependency pins, and inclusion of braintrace while removing pinnx.