### PR TITLE
docs: link ecosystem packages in brainpy-to-brainx guide

### DIFF
--- a/docs/brainpy-to-brainx.md
+++ b/docs/brainpy-to-brainx.md
@@ -1,91 +1,98 @@
----
-orphan: true
----
+# BrainPy to BrainX
 
-# brainpy to brainx
-
-`brainpy` is the experimental precursor to `brainx`. It served as an prototype for
-the later `brainx` ecosystem: the initial ideas explored in `brainpy` inspired
-the `brainx`, where those ideas were developed into focused,
+[`brainpy`][brainpy] is the experimental precursor to [`brainx`][brainx]. It served as an prototype for
+the later [`brainx`][brainx] ecosystem: the initial ideas explored in [`brainpy`][brainpy] inspired
+the [`brainx`][brainx], where those ideas were developed into focused,
 production-level packages.
 
-For example, the neural-mass modeling explored in `brainpy` later evolved into
-the dedicated `brainmass` package. The Hodgkin-Huxley cell models in `brainpy`
+For example, the neural-mass modeling explored in [`brainpy`][brainpy] later evolved into
+the dedicated [`brainmass`][brainmass] package. The Hodgkin-Huxley cell models in [`brainpy`][brainpy]
 inspired the more comprehensive conductance-based models, ion-channel systems,
-and neuronal morphology support now provided by `braincell`.
+and neuronal morphology support now provided by [`braincell`][braincell].
 
-`brainpy` remains useful as an experimental, legacy package and as the origin of many
-of the ecosystem's concepts. For new projects, `brainx` provides the
+[`brainpy`][brainpy] remains useful as an experimental, legacy package and as the origin of many
+of the ecosystem's concepts. For new projects, [`brainx`][brainx] provides the
 production-level implementations, broader capabilities, and better performance.
 
 ## Where brainpy fits
 
-`brainpy` was designed as a general-purpose package for brain dynamics
+[`brainpy`][brainpy] was designed as a general-purpose package for brain dynamics
 programming. Its main advantage was point-neuron modeling, that point-neuron scale has
-evolved into `brainpy.state`, the production-level point-neuron modeling package
-within `brainx`.
+evolved into [`brainpy.state`][brainpy.state], the production-level point-neuron modeling package
+within [`brainx`][brainx].
 
-For new point-neuron projects, use `brainpy.state`. Existing `brainpy` projects
+For new point-neuron projects, use [`brainpy.state`][brainpy.state]. Existing [`brainpy`][brainpy] projects
 do not need to be rewritten immediately if they already meet their goals.
 Migration becomes more valuable when a project needs deeper integration with
-the rest of `brainx`, newer infrastructure, or long-term ecosystem support.
+the rest of [`brainx`][brainx], newer infrastructure, or long-term ecosystem support.
 
 ## Compatibility
 
-The current `brainpy` codebase has been reconstructed on top of `brainstate`,
-`brainevent`, and `braintools`. This makes it compatible with those foundational
+The current [`brainpy`][brainpy] codebase has been reconstructed on top of [`brainstate`][brainstate],
+[`brainevent`][brainevent], and [`braintools`][braintools]. This makes it compatible with those foundational
 packages and with the modeling packages built on the same infrastructure.
 
 | package | compatibility |
 | --- | --- |
-| `brainstate` | compatible |
-| `brainevent` | compatible |
-| `braintools` | compatible |
-| `braincell` | compatible |
-| `brainmass` | compatible |
-| `brainunit` | not compatible |
-| `braintrace` | not compatible |
+| [`brainstate`][brainstate] | compatible |
+| [`brainevent`][brainevent] | compatible |
+| [`braintools`][braintools] | compatible |
+| [`braincell`][braincell] | compatible |
+| [`brainmass`][brainmass] | compatible |
+| [`brainunit`][brainunit] | not compatible |
+| [`braintrace`][braintrace] | not compatible |
 
-The `brainunit` and `braintrace` exceptions limit how fully a `brainpy` project
-can participate in the production-level `brainx` ecosystem.
+The [`brainunit`][brainunit] and [`braintrace`][braintrace] exceptions limit how fully a [`brainpy`][brainpy] project
+can participate in the production-level [`brainx`][brainx] ecosystem.
 
 ## Cellular modeling
 
 For biophysical neuron models involving ions, ion channels, compartments, or
-neuronal morphology, migrate completely to `brainpy.state` and `braincell`.
+neuronal morphology, migrate completely to [`brainpy.state`][brainpy.state] and [`braincell`][braincell].
 
-The older ion and channel APIs in `brainpy` have known design limitations, and
+The older ion and channel APIs in [`brainpy`][brainpy] have known design limitations, and
 its compartmental modeling support is restricted to single-compartment models.
-`braincell` provides more comprehensive conductance-based and Hodgkin-Huxley
+[`braincell`][braincell] provides more comprehensive conductance-based and Hodgkin-Huxley
 models together with morphologically structured, multicompartment cells.
-Mixing the experimental `brainpy` cell APIs into new `braincell`-based work is
+Mixing the experimental [`brainpy`][brainpy] cell APIs into new [`braincell`][braincell]-based work is
 therefore not recommended.
 
 ## The remaining brainpy exception: analysis
 
-The analysis module in `brainpy` is the main capability that does not yet have
-a direct replacement elsewhere in `brainx`. If a workflow depends on this
-module, `brainpy` may still be the appropriate tool for that part of the
+The analysis module in [`brainpy`][brainpy] is the main capability that does not yet have
+a direct replacement elsewhere in [`brainx`][brainx]. If a workflow depends on this
+module, [`brainpy`][brainpy] may still be the appropriate tool for that part of the
 project.
 
-This is the important exception to the general migration guidance: `brainx`
-covers the modeling and simulation roles of `brainpy`, but its dedicated
+This is the important exception to the general migration guidance: [`brainx`][brainx]
+covers the modeling and simulation roles of [`brainpy`][brainpy], but its dedicated
 analysis functionality remains unique for now.
 
 ## Quick decision guide
 
 | use case | recommended choice |
 | --- | --- |
-| Starting a new point-neuron project | `brainpy.state` |
-| Maintaining an existing `brainpy` project | Continue with `brainpy`; migrate for integration |
-| Modeling ions, ion channels, or morphology | `brainpy.state` and `braincell` |
-| Using `brainunit` or `braintrace` | Migrate away from `brainpy` |
-| Relying on the analysis module in `brainpy` | Continue using `brainpy` for analysis |
+| Starting a new point-neuron project | [`brainpy.state`][brainpy.state] |
+| Maintaining an existing [`brainpy`][brainpy] project | Continue with [`brainpy`][brainpy]; migrate for integration |
+| Modeling ions, ion channels, or morphology | [`brainpy.state`][brainpy.state] and [`braincell`][braincell] |
+| Using [`brainunit`][brainunit] or [`braintrace`][braintrace] | Migrate away from [`brainpy`][brainpy] |
+| Relying on the analysis module in [`brainpy`][brainpy] | Continue using [`brainpy`][brainpy] for analysis |
 
 ## In short
 
-Treat `brainpy` as the experimental embryo that inspired the `brainx` ecosystem.
+Treat [`brainpy`][brainpy] as the experimental embryo that inspired the [`brainx`][brainx] ecosystem.
 It remains usable for established projects and its unique analysis tools, but
-`brainx` is the production-level destination for new work. Use `brainpy.state`
-for point-neuron modeling, `braincell` for ions, channels, and morphology, and
-`brainmass` for neural-mass and whole-brain models.
+[`brainx`][brainx] is the production-level destination for new work. Use [`brainpy.state`][brainpy.state]
+for point-neuron modeling, [`braincell`][braincell] for ions, channels, and morphology, and
+[`brainmass`][brainmass] for neural-mass and whole-brain models.
+
+[brainx]: https://brainx.chaobrain.com/
+[brainpy]: https://brainpy.readthedocs.io/
+[brainpy.state]: https://brainx.chaobrain.com/brainpy-state/
+[brainstate]: https://brainx.chaobrain.com/brainstate/
+[brainevent]: https://brainx.chaobrain.com/brainevent/
+[braintools]: https://brainx.chaobrain.com/braintools/
+[braincell]: https://brainx.chaobrain.com/braincell/
+[brainmass]: https://brainx.chaobrain.com/brainmass/
+[brainunit]: https://brainx.chaobrain.com/brainunit/
+[braintrace]: https://brainx.chaobrain.com/braintrace/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ The tutorials are organized around the BrainX package layers:
 
    CHANGELOG.md
    install.md
+   brainpy-to-brainx.md
 
 
 .. toctree::


### PR DESCRIPTION
Links every package mention in `docs/brainpy-to-brainx.md` to its documentation, and puts the page into the docs navigation.

## Changes

- **Links.** Every occurrence of a package name in prose and in both tables is now a link — 59 in total. Headings are left unlinked, since links in headings interfere with anchor rendering.
- **Reference-style.** Uses MyST reference-style links with one definition block at the bottom, so each URL is defined exactly once.
- **Navigation.** Adds the page to the *Getting started* toctree in `docs/index.rst` and removes its `orphan: true` front matter, which would otherwise emit a Sphinx warning now that the page is reachable.
- **Title.** Capitalizes the heading as "BrainPy to BrainX".

## Link targets

Follows the scheme already used in `docs/index.rst`:

| package | URL | occurrences |
| --- | --- | --- |
| `brainpy` | `https://brainpy.readthedocs.io/` | 20 |
| `brainx` | `https://brainx.chaobrain.com/` | 11 |
| `braincell` | `…/braincell/` | 7 |
| `brainpy.state` | `…/brainpy-state/` | 6 |
| `brainmass`, `braintrace`, `brainunit` | `…/<name>/` | 3 each |
| `brainevent`, `brainstate`, `braintools` | `…/<name>/` | 2 each |

`brainpy` is the one exception to the `brainx.chaobrain.com/<name>/` scheme: that subpath returns 404, so it points at Read the Docs instead, matching `docs/install.md`.

## Verification

- All 10 URLs checked live — every `brainx.chaobrain.com/<pkg>/` returns 200, and `…/brainpy/` returns 404 (hence the Read the Docs target).
- Built the page inside a toctree with Sphinx under `-W --keep-going`: build succeeded, no orphan warning, no unresolved references.
- Audited the rendered HTML: all 59 anchors resolve and none point at the 404 URL.

A full `docs/` build was not run locally — `nbsphinx` is not installed in this environment — so CI covers the notebook-bearing toctrees.

## Summary by Sourcery

Link BrainPy/BrainX ecosystem packages from the migration guide to their documentation and integrate the page into the main docs navigation.

Documentation:
- Convert package mentions in the BrainPy-to-BrainX guide into reference-style links to their respective documentation pages.
- Retitle the BrainPy-to-BrainX guide heading for consistent capitalization and remove orphan metadata now that it is linked from the docs.