### PR TITLE
docs: split the BrainPy guide into a concept page and migration notes

### DIFF
--- a/docs/brainpy-migration-notes.md
+++ b/docs/brainpy-migration-notes.md
@@ -1,0 +1,245 @@
+# BrainPy migration notes
+
+Practical notes for moving a [`brainpy`][brainpy] project onto the
+[`brainx`][brainx] packages: what maps to what, a worked before/after example, and the
+cases that do not carry over.
+
+For why the ecosystem is arranged this way, which package owns which modeling scale,
+and whether your project should move at all, read
+[BrainPy to BrainX](./brainpy-to-brainx.md) first.
+
+## The two packages at a glance
+
+`brainpy` and `brainpy.state` share an import root and nothing else:
+
+| | `brainpy` | `brainpy.state` |
+| --- | --- | --- |
+| import | `import brainpy as bp` | `import brainpy.state` |
+| PyPI distribution | `brainpy` | `brainpy-state` |
+| state objects | `brainpy.math.Variable` | `brainstate.State` |
+| module base class | `brainpy.DynamicalSystem` | `brainstate.nn.Module` |
+| simulation loop | `brainpy.DSRunner` | `brainstate.transform.for_loop` |
+| parameters | plain floats (ms, mV by convention) | [`brainunit`][brainunit] quantities |
+
+Both are installed by `pip install -U BrainX`, or separately with
+`pip install brainpy brainpy-state`. They import cleanly into the same process, so a
+project can migrate one model at a time.
+
+## Migration in four steps
+
+Migration is incremental. In order of effort and payoff:
+
+1. **Port the model definition.** `brainpy.DynamicalSystem` → `brainstate.nn.Module`,
+   `brainpy.dyn.*` → `brainpy.state.*`. Add units to parameters as you go.
+2. **Replace the runner.** `brainpy.DSRunner` / `brainpy.LoopOverTime` →
+   `brainstate.transform.for_loop`. Never drive the model with a bare Python loop:
+   `for_loop` traces the body once and compiles the whole rollout into a single XLA
+   program.
+3. **Swap the helper modules** — losses, initializers, inputs, connectivity and plots all
+   move to [`braintools`][braintools] (table below). These are mostly mechanical renames.
+4. **Leave `brainpy.analysis` where it is.** Keep a reduced `brainpy` model alongside the
+   migrated one if you need phase-plane or bifurcation analysis.
+
+## Worked example: an E/I network
+
+The same conductance-based E/I network, before and after. Both versions run against the
+pinned releases and produce comparable firing statistics.
+
+**Before — `brainpy`:**
+
+```python
+import brainpy as bp
+import brainpy.math as bm
+
+bm.set_dt(0.1)
+
+
+class EINet(bp.DynSysGroup):
+    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
+        super().__init__()
+        num = n_exc + n_inh
+        self.n_exc = n_exc
+        self.N = bp.dyn.LifRef(
+            num, V_rest=-60., V_th=-50., V_reset=-60.,
+            tau=20., tau_ref=5.,
+            V_initializer=bp.init.Normal(-55., 2.),
+        )
+        self.delay = bp.VarDelay(self.N.spike, entries={'I': None})
+        self.E = bp.dyn.HalfProjAlignPostMg(
+            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_exc, post=num), weight=0.6),
+            syn=bp.dyn.Expon.desc(size=num, tau=5.),
+            out=bp.dyn.COBA.desc(E=0.),
+            post=self.N,
+        )
+        self.I = bp.dyn.HalfProjAlignPostMg(
+            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_inh, post=num), weight=6.7),
+            syn=bp.dyn.Expon.desc(size=num, tau=10.),
+            out=bp.dyn.COBA.desc(E=-80.),
+            post=self.N,
+        )
+
+    def update(self, inp=20.):
+        spk = self.delay.at('I')
+        self.E(spk[:self.n_exc])
+        self.I(spk[self.n_exc:])
+        self.delay(self.N(inp))
+        return self.N.spike.value
+
+
+net = EINet()
+runner = bp.DSRunner(net, monitors=['N.spike'])
+runner.run(100.)
+spikes = runner.mon['N.spike']
+```
+
+**After — `brainpy.state`:**
+
+```python
+import brainpy.state
+import brainstate
+import braintools
+import brainunit as u
+
+brainstate.environ.set(dt=0.1 * u.ms)
+
+
+class EINet(brainstate.nn.Module):
+    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
+        super().__init__()
+        num = n_exc + n_inh
+        self.n_exc = n_exc
+        self.N = brainpy.state.LIFRef(
+            num, V_rest=-60. * u.mV, V_th=-50. * u.mV, V_reset=-60. * u.mV,
+            tau=20. * u.ms, tau_ref=5. * u.ms,
+            V_initializer=braintools.init.Normal(-55. * u.mV, 2. * u.mV),
+        )
+        self.E = brainpy.state.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(n_exc, num, prob, 0.6 * u.mS),
+            syn=brainpy.state.Expon.desc(num, tau=5. * u.ms),
+            out=brainpy.state.COBA.desc(E=0. * u.mV),
+            post=self.N,
+        )
+        self.I = brainpy.state.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(n_inh, num, prob, 6.7 * u.mS),
+            syn=brainpy.state.Expon.desc(num, tau=10. * u.ms),
+            out=brainpy.state.COBA.desc(E=-80. * u.mV),
+            post=self.N,
+        )
+
+    def update(self, t, inp):
+        with brainstate.environ.context(t=t):
+            spk = self.N.get_spike() != 0.
+            self.E(spk[:self.n_exc])
+            self.I(spk[self.n_exc:])
+            self.N(inp)
+            return self.N.get_spike()
+
+
+net = EINet()
+brainstate.nn.init_all_states(net)
+
+times = u.math.arange(0. * u.ms, 100. * u.ms, brainstate.environ.get_dt())
+spikes = brainstate.transform.for_loop(lambda t: net.update(t, 20. * u.mA), times)
+```
+
+Four differences carry most of the work: parameters carry units, states are initialized
+explicitly with `init_all_states`, the delay bookkeeping moves into the projection
+instead of an explicit `VarDelay`, and the runner is replaced by a compiled `for_loop`.
+
+## Runtime mapping
+
+| `brainpy` | [`brainx`][brainx] |
+| --- | --- |
+| `brainpy.math.Variable` | `brainstate.HiddenState` / `brainstate.ParamState` |
+| `brainpy.DynamicalSystem`, `brainpy.DynSysGroup` | `brainstate.nn.Module` |
+| `brainpy.DSRunner`, `brainpy.LoopOverTime` | `brainstate.transform.for_loop` / `scan` |
+| `brainpy.math.jit` | `brainstate.transform.jit` |
+| `brainpy.math.random` | `brainstate.random` |
+| `brainpy.math.set_dt`, `brainpy.share` | `brainstate.environ` |
+| `brainpy.BPTT` and the trainers | `brainstate.transform` gradients + `braintools.optim` |
+| long rollouts under autograd | `brainstate.transform.checkpointed_for_loop` |
+
+## Module mapping
+
+| `brainpy` | [`brainx`][brainx] |
+| --- | --- |
+| `brainpy.dyn` (point neurons, synapses, projections) | `brainpy.state` |
+| `brainpy.dyn` channels, ions, `CondNeuGroup` | [`braincell`][braincell] |
+| `brainpy.rates`, `brainpy.dyn` rate models | [`brainmass`][brainmass] |
+| `brainpy.dnn`, `brainpy.layers` | `brainstate.nn` |
+| `brainpy.losses`, `brainpy.measure` | `braintools.metric` |
+| `brainpy.initialize` | `braintools.init` |
+| `brainpy.inputs` | `braintools.input` |
+| `brainpy.conn` | `braintools.conn` |
+| `brainpy.optim` | `braintools.optim` |
+| `brainpy.visualization` | `braintools.visualize` |
+| `brainpy.encoding` | `braintools` encoders |
+| `brainpy.math.surrogate` | `braintools.surrogate` |
+| `brainpy.math.sparse`, `.event`, `.jitconn` | [`brainevent`][brainevent] |
+| `brainpy.odeint`, `brainpy.sdeint` | `braintools.quad`, `brainstate.nn.exp_euler_step` |
+| `brainpy.analysis` | *no replacement — see below* |
+
+## What does not carry over
+
+**`brainunit` quantities.** `brainpy` depends on [`brainunit`][brainunit] internally, but
+its array layer does not accept quantities:
+
+```python
+>>> import brainpy.math as bm, brainunit as u
+>>> bm.exp(10. * u.mV)
+TypeError: exp requires ndarray or scalar arguments, got <class 'saiunit.Quantity'> at position 0.
+```
+
+Strip units at the boundary — `(10. * u.mV).to_decimal(u.mV)` — or migrate the model.
+End-to-end unit safety is only available on the [`brainx`][brainx] side.
+
+**Online learning.** [`braintrace`][braintrace] attaches eligibility traces to operations
+inside `brainstate`-based modules. It cannot see a `brainpy.math.Variable` graph, so
+`brainpy` models cannot be trained online with it.
+
+**Mixed model trees.** Modules from the two state systems cannot be composed into one
+model. A `brainpy.state` module placed inside a `brainpy.DynSysGroup` never gets its
+states initialized, and fails at run time:
+
+```python
+AttributeError: 'LIF' object has no attribute 'V'
+```
+
+Port whole models, not individual layers. The two can still live in the same script as
+separate models.
+
+**Analysis.** `brainpy.analysis` — phase-plane analyzers, `Bifurcation1D` /
+`Bifurcation2D`, slow-fast decomposition — has no counterpart in [`brainx`][brainx]. The
+usual pattern is to keep a reduced `brainpy` model for analysis alongside the migrated
+simulation model.
+
+## Compatibility matrix
+
+Which ecosystem packages a `brainpy` project can use, and which can be built into the
+same model:
+
+| package | usable alongside `brainpy` | composable into one `brainpy` model |
+| --- | --- | --- |
+| [`brainstate`][brainstate] | yes — `brainpy` is built on it | — |
+| [`brainevent`][brainevent] | yes — `brainpy` operators delegate to it | — |
+| [`braintools`][braintools] | yes — `brainpy` helpers delegate to it | — |
+| [`braincell`][braincell] | yes, as a separate model | no |
+| [`brainmass`][brainmass] | yes, as a separate model | no |
+| [`brainunit`][brainunit] | only outside `brainpy.math` | no |
+| [`braintrace`][braintrace] | no | no |
+
+## Where to go next
+
+For a hands-on introduction to the target APIs, work through the
+[point-neuron network tutorial](./tutorials/brainpy_point_neuron_networks.ipynb).
+
+[brainx]: https://brainx.chaobrain.com/
+[brainpy]: https://brainpy.readthedocs.io/
+[brainpy.state]: https://brainx.chaobrain.com/brainpy-state/
+[brainstate]: https://brainx.chaobrain.com/brainstate/
+[brainevent]: https://brainx.chaobrain.com/brainevent/
+[braintools]: https://brainx.chaobrain.com/braintools/
+[braincell]: https://brainx.chaobrain.com/braincell/
+[brainmass]: https://brainx.chaobrain.com/brainmass/
+[brainunit]: https://brainx.chaobrain.com/brainunit/
+[braintrace]: https://brainx.chaobrain.com/braintrace/

--- a/docs/brainpy-to-brainx.md
+++ b/docs/brainpy-to-brainx.md
@@ -1,46 +1,101 @@
 # BrainPy to BrainX
 
-[`brainpy`][brainpy] is the experimental precursor of [`brainx`][brainx]. The ideas it
-prototyped — stateful dynamical systems, event-driven operators, unit-aware
-parameters — were developed into the focused, production-level packages that
-make up the [`brainx`][brainx] ecosystem today.
+[`brainpy`][brainpy] is the experimental precursor of [`brainx`][brainx]. It served as
+the prototype for the later ecosystem: the ideas first explored in
+[`brainpy`][brainpy] — stateful dynamical systems, event-driven operators, unit-aware
+parameters — were developed into the focused, production-level packages that make up
+[`brainx`][brainx] today.
 
-This page explains what changed, whether your project should move, and exactly
-how to move it.
+The neural-mass modeling explored in [`brainpy`][brainpy] evolved into the dedicated
+[`brainmass`][brainmass] package. Its Hodgkin-Huxley cell models inspired the more
+comprehensive conductance-based models, ion-channel systems, and neuronal morphology
+support now provided by [`braincell`][braincell]. Its point-neuron modeling — the part
+[`brainpy`][brainpy] was best at — became [`brainpy.state`][brainpy.state].
 
-:::{important}
-**`brainpy` and `brainpy.state` are two different packages.** They share an
-import root and nothing else. Most of the confusion around migration comes from
-this one fact, so it is worth reading the table below before anything else.
+This page explains how the packages relate and whether your project should move.
+When you decide to move, the [migration notes](./brainpy-migration-notes.md) cover the
+mechanics: API mappings, a worked before/after example, and the cases that need care.
 
-| | `brainpy` | `brainpy.state` |
-| --- | --- | --- |
-| import | `import brainpy as bp` | `import brainpy.state` |
-| PyPI distribution | `brainpy` | `brainpy-state` |
-| state objects | `brainpy.math.Variable` | `brainstate.State` |
-| module base class | `brainpy.DynamicalSystem` | `brainstate.nn.Module` |
-| simulation loop | `brainpy.DSRunner` | `brainstate.transform.for_loop` |
-| parameters | plain floats (ms, mV by convention) | [`brainunit`][brainunit] quantities |
+## `brainpy` and `brainpy.state`
 
-Both are installed by `pip install -U BrainX`, or separately with
-`pip install brainpy brainpy-state`. They import cleanly into the same process,
-so a project can migrate one model at a time.
-:::
+`brainpy` and `brainpy.state` are two different packages. They share an import root
+and little else: they are distributed separately on PyPI (`brainpy` and
+`brainpy-state`), and they are built on different state systems — `brainpy` on its own
+`brainpy.math.Variable`, `brainpy.state` on [`brainstate`][brainstate].
+
+Most of the confusion around migration comes from this one fact. Both are installed by
+`pip install -U BrainX` and import cleanly into the same process, so a project can
+migrate one model at a time. The
+[migration notes](./brainpy-migration-notes.md) tabulate the differences.
 
 ## Status and support
 
-This guide describes `brainpy` 2.x and the component versions pinned by the
-current [`brainx`][brainx] release; see the [change log](./CHANGELOG.md) for the
-exact pins.
+This page describes `brainpy` 2.x and the component versions pinned by the current
+[`brainx`][brainx] release; see the [change log](./CHANGELOG.md) for the exact pins.
 
 `brainpy` ships in the BrainX pin set and is in **maintenance**: it receives
-compatibility and bug fixes (for example the recent JAX 0.11 fix), and its
-`analysis` module is still unique in the ecosystem. New modeling features land
-in the [`brainx`][brainx] packages, not in `brainpy`.
+compatibility and bug fixes (for example the recent JAX 0.11 fix), and its `analysis`
+module is still unique in the ecosystem. New modeling features land in the
+[`brainx`][brainx] packages, not in `brainpy`.
 
-Existing `brainpy` projects do not need to be rewritten. Migration pays off when
-a project needs unit-safe parameters, multicompartment cells, online learning,
-or long-term feature work.
+Existing `brainpy` projects do not need to be rewritten. Migration pays off when a
+project needs unit-safe parameters, multicompartment cells, online learning, or
+long-term feature work.
+
+## Where each modeling scale now lives
+
+**Point-neuron networks → [`brainpy.state`][brainpy.state].** This was `brainpy`'s main
+strength, and it is the scale that carried over most directly. Model names and
+projection patterns stay recognizable; the state system and the runner are what change.
+
+**Cells, ions, and morphology → [`braincell`][braincell].** Migrate rather than mix. The
+older ion and channel APIs in `brainpy` have known design limitations and its
+compartmental support is restricted to single-compartment models.
+[`braincell`][braincell] provides comprehensive conductance-based and Hodgkin-Huxley
+models together with morphologically structured, multicompartment cells.
+
+**Neural-mass and whole-brain models → [`brainmass`][brainmass].** The `brainpy` rate
+models cover FitzHugh-Nagumo, Stuart-Landau, threshold-linear, and Wilson-Cowan
+dynamics. [`brainmass`][brainmass] provides direct counterparts, plus models `brainpy`
+never had — Jansen-Rit, Epileptor, Hopf, Montbrió-Pazó-Roxin, Wong-Wang,
+Larter-Breakspear — and the infrastructure whole-brain work needs: explicit coupling
+schemes, structured noise processes, forward models for BOLD, EEG, and MEG signals, and
+parameter fitting against empirical data. Unlike the cellular case this is not a
+warning; the `brainpy` rate models still work, this scale is simply developed in
+[`brainmass`][brainmass] now.
+
+## Why existing brainpy code still works
+
+The current `brainpy` codebase was reconstructed on top of [`brainstate`][brainstate],
+[`brainevent`][brainevent], and [`braintools`][braintools]. This is not only a dependency
+relationship: many internal functions delegate to the production-level implementations,
+so the two share the same underlying code rather than maintaining parallel ports.
+
+- `brainpy.math.surrogate` is an alias of `braintools.surrogate`, and the einops-style
+  helpers in `brainpy.math` are re-exported from `brainunit.math`.
+- The operators in `brainpy.math.sparse`, `brainpy.math.event`, and
+  `brainpy.math.jitconn` build [`brainevent`][brainevent] structures such as `CSR`,
+  `CSC`, and the just-in-time connectivity types, then hand the computation over to them.
+- `brainpy.losses` and `brainpy.measure` delegate to `braintools.metric`, and
+  `brainpy.initialize` delegates to `braintools.init`.
+- `brainpy.inputs` builds its current waveforms from `braintools.input`, and
+  `brainpy.visualization` from `braintools.visualize`.
+- State handling, environment settings, and compiled transformations come from
+  [`brainstate`][brainstate], through `State`, `environ`, and `transform`.
+
+So a `brainpy` project keeps working and stays on the same foundations as the rest of
+the ecosystem. Two packages sit outside that arrangement: [`brainunit`][brainunit],
+whose quantities `brainpy.math` cannot consume, and [`braintrace`][braintrace], whose
+online-learning traces attach to [`brainstate`][brainstate] modules only. Sharing
+foundations also does not mean models from both sides can be composed into one — see
+the [migration notes](./brainpy-migration-notes.md) for both limits in detail.
+
+## What brainpy still owns
+
+`brainpy.analysis` — phase-plane analyzers, `Bifurcation1D` / `Bifurcation2D`, slow-fast
+decomposition — has no counterpart in [`brainx`][brainx]. This is the one capability for
+which `brainpy` remains the right tool, and the reason it stays in the pin set rather
+than being retired.
 
 ## Should I migrate?
 
@@ -54,269 +109,17 @@ or long-term feature work.
 | Wanting online learning ([`braintrace`][braintrace]) | migrate — traces attach to `brainstate` modules only |
 | Depending on `brainpy.analysis` | stay on `brainpy` for that part |
 
-## How to migrate
-
-Migration is incremental. In order of effort and payoff:
-
-1. **Port the model definition.** `brainpy.DynamicalSystem` → `brainstate.nn.Module`,
-   `brainpy.dyn.*` → `brainpy.state.*`. Add units to parameters as you go.
-2. **Replace the runner.** `brainpy.DSRunner` / `brainpy.LoopOverTime` →
-   `brainstate.transform.for_loop`. Never drive the model with a bare Python
-   loop: `for_loop` traces the body once and compiles the whole rollout into a
-   single XLA program.
-3. **Swap the helper modules** — losses, initializers, inputs, connectivity and
-   plots all move to [`braintools`][braintools] (table below). These are mostly
-   mechanical renames.
-4. **Leave `brainpy.analysis` where it is.** Keep a reduced `brainpy` model
-   alongside the migrated one if you need phase-plane or bifurcation analysis.
-
-### Worked example: an E/I network
-
-The same conductance-based E/I network, before and after. Both versions run
-against the pinned releases and produce comparable firing statistics.
-
-**Before — `brainpy`:**
-
-```python
-import brainpy as bp
-import brainpy.math as bm
-
-bm.set_dt(0.1)
-
-
-class EINet(bp.DynSysGroup):
-    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
-        super().__init__()
-        num = n_exc + n_inh
-        self.n_exc = n_exc
-        self.N = bp.dyn.LifRef(
-            num, V_rest=-60., V_th=-50., V_reset=-60.,
-            tau=20., tau_ref=5.,
-            V_initializer=bp.init.Normal(-55., 2.),
-        )
-        self.delay = bp.VarDelay(self.N.spike, entries={'I': None})
-        self.E = bp.dyn.HalfProjAlignPostMg(
-            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_exc, post=num), weight=0.6),
-            syn=bp.dyn.Expon.desc(size=num, tau=5.),
-            out=bp.dyn.COBA.desc(E=0.),
-            post=self.N,
-        )
-        self.I = bp.dyn.HalfProjAlignPostMg(
-            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_inh, post=num), weight=6.7),
-            syn=bp.dyn.Expon.desc(size=num, tau=10.),
-            out=bp.dyn.COBA.desc(E=-80.),
-            post=self.N,
-        )
-
-    def update(self, inp=20.):
-        spk = self.delay.at('I')
-        self.E(spk[:self.n_exc])
-        self.I(spk[self.n_exc:])
-        self.delay(self.N(inp))
-        return self.N.spike.value
-
-
-net = EINet()
-runner = bp.DSRunner(net, monitors=['N.spike'])
-runner.run(100.)
-spikes = runner.mon['N.spike']
-```
-
-**After — `brainpy.state`:**
-
-```python
-import brainpy.state
-import brainstate
-import braintools
-import brainunit as u
-
-brainstate.environ.set(dt=0.1 * u.ms)
-
-
-class EINet(brainstate.nn.Module):
-    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
-        super().__init__()
-        num = n_exc + n_inh
-        self.n_exc = n_exc
-        self.N = brainpy.state.LIFRef(
-            num, V_rest=-60. * u.mV, V_th=-50. * u.mV, V_reset=-60. * u.mV,
-            tau=20. * u.ms, tau_ref=5. * u.ms,
-            V_initializer=braintools.init.Normal(-55. * u.mV, 2. * u.mV),
-        )
-        self.E = brainpy.state.AlignPostProj(
-            comm=brainstate.nn.EventFixedProb(n_exc, num, prob, 0.6 * u.mS),
-            syn=brainpy.state.Expon.desc(num, tau=5. * u.ms),
-            out=brainpy.state.COBA.desc(E=0. * u.mV),
-            post=self.N,
-        )
-        self.I = brainpy.state.AlignPostProj(
-            comm=brainstate.nn.EventFixedProb(n_inh, num, prob, 6.7 * u.mS),
-            syn=brainpy.state.Expon.desc(num, tau=10. * u.ms),
-            out=brainpy.state.COBA.desc(E=-80. * u.mV),
-            post=self.N,
-        )
-
-    def update(self, t, inp):
-        with brainstate.environ.context(t=t):
-            spk = self.N.get_spike() != 0.
-            self.E(spk[:self.n_exc])
-            self.I(spk[self.n_exc:])
-            self.N(inp)
-            return self.N.get_spike()
-
-
-net = EINet()
-brainstate.nn.init_all_states(net)
-
-times = u.math.arange(0. * u.ms, 100. * u.ms, brainstate.environ.get_dt())
-spikes = brainstate.transform.for_loop(lambda t: net.update(t, 20. * u.mA), times)
-```
-
-Four differences carry most of the work: parameters carry units, states are
-initialized explicitly with `init_all_states`, the delay bookkeeping moves into
-the projection instead of an explicit `VarDelay`, and the runner is replaced by a
-compiled `for_loop`.
-
-### Runtime mapping
-
-| `brainpy` | [`brainx`][brainx] |
-| --- | --- |
-| `brainpy.math.Variable` | `brainstate.HiddenState` / `brainstate.ParamState` |
-| `brainpy.DynamicalSystem`, `brainpy.DynSysGroup` | `brainstate.nn.Module` |
-| `brainpy.DSRunner`, `brainpy.LoopOverTime` | `brainstate.transform.for_loop` / `scan` |
-| `brainpy.math.jit` | `brainstate.transform.jit` |
-| `brainpy.math.random` | `brainstate.random` |
-| `brainpy.math.set_dt`, `brainpy.share` | `brainstate.environ` |
-| `brainpy.BPTT` and the trainers | `brainstate.transform` gradients + `braintools.optim` |
-| long rollouts under autograd | `brainstate.transform.checkpointed_for_loop` |
-
-### Module mapping
-
-| `brainpy` | [`brainx`][brainx] |
-| --- | --- |
-| `brainpy.dyn` (point neurons, synapses, projections) | `brainpy.state` |
-| `brainpy.dyn` channels, ions, `CondNeuGroup` | [`braincell`][braincell] |
-| `brainpy.rates`, `brainpy.dyn` rate models | [`brainmass`][brainmass] |
-| `brainpy.dnn`, `brainpy.layers` | `brainstate.nn` |
-| `brainpy.losses`, `brainpy.measure` | `braintools.metric` |
-| `brainpy.initialize` | `braintools.init` |
-| `brainpy.inputs` | `braintools.input` |
-| `brainpy.conn` | `braintools.conn` |
-| `brainpy.optim` | `braintools.optim` |
-| `brainpy.visualization` | `braintools.visualize` |
-| `brainpy.encoding` | `braintools` encoders |
-| `brainpy.math.surrogate` | `braintools.surrogate` |
-| `brainpy.math.sparse`, `.event`, `.jitconn` | [`brainevent`][brainevent] |
-| `brainpy.odeint`, `brainpy.sdeint` | `braintools.quad`, `brainstate.nn.exp_euler_step` |
-| `brainpy.analysis` | *no replacement — see below* |
-
-## What does not carry over
-
-**`brainunit` quantities.** `brainpy` depends on [`brainunit`][brainunit]
-internally, but its array layer does not accept quantities:
-
-```python
->>> import brainpy.math as bm, brainunit as u
->>> bm.exp(10. * u.mV)
-TypeError: exp requires ndarray or scalar arguments, got <class 'saiunit.Quantity'> at position 0.
-```
-
-Strip units at the boundary — `(10. * u.mV).to_decimal(u.mV)` — or migrate the
-model. End-to-end unit safety is only available on the [`brainx`][brainx] side.
-
-**Online learning.** [`braintrace`][braintrace] attaches eligibility traces to
-operations inside `brainstate`-based modules. It cannot see a
-`brainpy.math.Variable` graph, so `brainpy` models cannot be trained online
-with it.
-
-**Mixed model trees.** Modules from the two state systems cannot be composed into
-one model. A `brainpy.state` module placed inside a `brainpy.DynSysGroup` never
-gets its states initialized, and fails at run time:
-
-```python
-AttributeError: 'LIF' object has no attribute 'V'
-```
-
-Port whole models, not individual layers. The two can still live in the same
-script as separate models.
-
-**Analysis.** `brainpy.analysis` — phase-plane analyzers, `Bifurcation1D` /
-`Bifurcation2D`, slow-fast decomposition — has no counterpart in
-[`brainx`][brainx]. This is the one capability for which `brainpy` remains the
-right tool. The usual pattern is to keep a reduced `brainpy` model for analysis
-alongside the migrated simulation model.
-
-## Why existing brainpy code still works
-
-The current `brainpy` codebase was reconstructed on top of
-[`brainstate`][brainstate], [`brainevent`][brainevent], and
-[`braintools`][braintools]. This is not only a dependency relationship: many
-internal functions delegate to the production-level implementations, so the two
-share the same underlying code rather than maintaining parallel ports.
-
-- `brainpy.math.surrogate` is an alias of `braintools.surrogate`, and the
-  einops-style helpers in `brainpy.math` are re-exported from `brainunit.math`.
-- The operators in `brainpy.math.sparse`, `brainpy.math.event`, and
-  `brainpy.math.jitconn` build [`brainevent`][brainevent] structures such as
-  `CSR`, `CSC`, and the just-in-time connectivity types, then hand the
-  computation over to them.
-- `brainpy.losses` and `brainpy.measure` delegate to `braintools.metric`, and
-  `brainpy.initialize` delegates to `braintools.init`.
-- `brainpy.inputs` builds its current waveforms from `braintools.input`, and
-  `brainpy.visualization` from `braintools.visualize`.
-- State handling, environment settings, and compiled transformations come from
-  [`brainstate`][brainstate], through `State`, `environ`, and `transform`.
-
-Practically, this means a `brainpy` project keeps working and stays on the same
-foundations as the rest of the ecosystem. It does *not* mean models from both
-sides can be composed:
-
-| package | usable alongside `brainpy` | composable into one `brainpy` model |
-| --- | --- | --- |
-| [`brainstate`][brainstate] | yes — `brainpy` is built on it | — |
-| [`brainevent`][brainevent] | yes — `brainpy` operators delegate to it | — |
-| [`braintools`][braintools] | yes — `brainpy` helpers delegate to it | — |
-| [`braincell`][braincell] | yes, as a separate model | no |
-| [`brainmass`][brainmass] | yes, as a separate model | no |
-| [`brainunit`][brainunit] | only outside `brainpy.math` | no |
-| [`braintrace`][braintrace] | no | no |
-
-## Where each modeling scale now lives
-
-**Point-neuron networks → [`brainpy.state`][brainpy.state].** This was
-`brainpy`'s main strength, and it is the scale that carried over most directly.
-Model names and projection patterns stay recognizable; the state system and the
-runner are what change.
-
-**Cells, ions, and morphology → [`braincell`][braincell].** Migrate rather than
-mix. The older ion and channel APIs in `brainpy` have known design limitations
-and its compartmental support is restricted to single-compartment models.
-[`braincell`][braincell] provides comprehensive conductance-based and
-Hodgkin-Huxley models together with morphologically structured, multicompartment
-cells.
-
-**Neural-mass and whole-brain models → [`brainmass`][brainmass].** The `brainpy`
-rate models cover FitzHugh-Nagumo, Stuart-Landau, threshold-linear, and
-Wilson-Cowan dynamics. [`brainmass`][brainmass] provides direct counterparts,
-plus models `brainpy` never had — Jansen-Rit, Epileptor, Hopf,
-Montbrió-Pazó-Roxin, Wong-Wang, Larter-Breakspear — and the infrastructure
-whole-brain work needs: explicit coupling schemes, structured noise processes,
-forward models for BOLD, EEG, and MEG signals, and parameter fitting against
-empirical data. Unlike the cellular case this is not a warning; the `brainpy`
-rate models still work, this scale is simply developed in
-[`brainmass`][brainmass] now.
-
 ## In short
 
 Treat `brainpy` as the experimental embryo that inspired the [`brainx`][brainx]
-ecosystem. It remains maintained and usable for established projects and for its
-unique analysis tools, while [`brainx`][brainx] is where new work belongs:
-[`brainpy.state`][brainpy.state] for point-neuron networks,
-[`braincell`][braincell] for ions, channels, and morphology, and
-[`brainmass`][brainmass] for neural-mass and whole-brain models.
+ecosystem. It remains maintained and usable for established projects and for its unique
+analysis tools, while [`brainx`][brainx] is where new work belongs:
+[`brainpy.state`][brainpy.state] for point-neuron networks, [`braincell`][braincell] for
+ions, channels, and morphology, and [`brainmass`][brainmass] for neural-mass and
+whole-brain models.
 
-For a hands-on introduction to the target APIs, see the
-[point-neuron network tutorial](./tutorials/brainpy_point_neuron_networks.ipynb).
+Ready to move? Continue with the
+[BrainPy migration notes](./brainpy-migration-notes.md).
 
 [brainx]: https://brainx.chaobrain.com/
 [brainpy]: https://brainpy.readthedocs.io/

--- a/docs/brainpy-to-brainx.md
+++ b/docs/brainpy-to-brainx.md
@@ -1,128 +1,322 @@
 # BrainPy to BrainX
 
-[`brainpy`][brainpy] is the experimental precursor to [`brainx`][brainx]. It served as an prototype for
-the later [`brainx`][brainx] ecosystem: the initial ideas explored in [`brainpy`][brainpy] inspired
-the [`brainx`][brainx], where those ideas were developed into focused,
-production-level packages.
+[`brainpy`][brainpy] is the experimental precursor of [`brainx`][brainx]. The ideas it
+prototyped — stateful dynamical systems, event-driven operators, unit-aware
+parameters — were developed into the focused, production-level packages that
+make up the [`brainx`][brainx] ecosystem today.
 
-For example, the neural-mass modeling explored in [`brainpy`][brainpy] later evolved into
-the dedicated [`brainmass`][brainmass] package. The Hodgkin-Huxley cell models in [`brainpy`][brainpy]
-inspired the more comprehensive conductance-based models, ion-channel systems,
-and neuronal morphology support now provided by [`braincell`][braincell].
+This page explains what changed, whether your project should move, and exactly
+how to move it.
 
-[`brainpy`][brainpy] remains useful as an experimental, legacy package and as the origin of many
-of the ecosystem's concepts. For new projects, [`brainx`][brainx] provides the
-production-level implementations, broader capabilities, and better performance.
+:::{important}
+**`brainpy` and `brainpy.state` are two different packages.** They share an
+import root and nothing else. Most of the confusion around migration comes from
+this one fact, so it is worth reading the table below before anything else.
 
-## Where brainpy fits
+| | `brainpy` | `brainpy.state` |
+| --- | --- | --- |
+| import | `import brainpy as bp` | `import brainpy.state` |
+| PyPI distribution | `brainpy` | `brainpy-state` |
+| state objects | `brainpy.math.Variable` | `brainstate.State` |
+| module base class | `brainpy.DynamicalSystem` | `brainstate.nn.Module` |
+| simulation loop | `brainpy.DSRunner` | `brainstate.transform.for_loop` |
+| parameters | plain floats (ms, mV by convention) | [`brainunit`][brainunit] quantities |
 
-[`brainpy`][brainpy] was designed as a general-purpose package for brain dynamics
-programming. Its main advantage was point-neuron modeling, that point-neuron scale has
-evolved into [`brainpy.state`][brainpy.state], the production-level point-neuron modeling package
-within [`brainx`][brainx].
+Both are installed by `pip install -U BrainX`, or separately with
+`pip install brainpy brainpy-state`. They import cleanly into the same process,
+so a project can migrate one model at a time.
+:::
 
-For new point-neuron projects, use [`brainpy.state`][brainpy.state]. Existing [`brainpy`][brainpy] projects
-do not need to be rewritten immediately if they already meet their goals.
-Migration becomes more valuable when a project needs deeper integration with
-the rest of [`brainx`][brainx], newer infrastructure, or long-term ecosystem support.
+## Status and support
 
-## Compatibility
+This guide describes `brainpy` 2.x and the component versions pinned by the
+current [`brainx`][brainx] release; see the [change log](./CHANGELOG.md) for the
+exact pins.
 
-The current [`brainpy`][brainpy] codebase has been reconstructed on top of [`brainstate`][brainstate],
-[`brainevent`][brainevent], and [`braintools`][braintools]. This makes it compatible with those foundational
-packages and with the modeling packages built on the same infrastructure.
+`brainpy` ships in the BrainX pin set and is in **maintenance**: it receives
+compatibility and bug fixes (for example the recent JAX 0.11 fix), and its
+`analysis` module is still unique in the ecosystem. New modeling features land
+in the [`brainx`][brainx] packages, not in `brainpy`.
 
-This is not only a dependency relationship. Many internal functions of
-[`brainpy`][brainpy] have been rewritten to delegate to the production-level
-implementations, so the two share the same underlying code rather than
-maintaining parallel ports. For example:
+Existing `brainpy` projects do not need to be rewritten. Migration pays off when
+a project needs unit-safe parameters, multicompartment cells, online learning,
+or long-term feature work.
+
+## Should I migrate?
+
+| your situation | recommendation |
+| --- | --- |
+| Starting a new point-neuron project | [`brainpy.state`][brainpy.state] |
+| Maintaining a working `brainpy` project | stay; migrate when you need something below |
+| Modeling ions, ion channels, or morphology | [`brainpy.state`][brainpy.state] + [`braincell`][braincell] — migrate |
+| Modeling neural-mass or whole-brain dynamics | [`brainmass`][brainmass] |
+| Wanting unit-safe parameters ([`brainunit`][brainunit]) | migrate — `brainpy.math` cannot consume quantities |
+| Wanting online learning ([`braintrace`][braintrace]) | migrate — traces attach to `brainstate` modules only |
+| Depending on `brainpy.analysis` | stay on `brainpy` for that part |
+
+## How to migrate
+
+Migration is incremental. In order of effort and payoff:
+
+1. **Port the model definition.** `brainpy.DynamicalSystem` → `brainstate.nn.Module`,
+   `brainpy.dyn.*` → `brainpy.state.*`. Add units to parameters as you go.
+2. **Replace the runner.** `brainpy.DSRunner` / `brainpy.LoopOverTime` →
+   `brainstate.transform.for_loop`. Never drive the model with a bare Python
+   loop: `for_loop` traces the body once and compiles the whole rollout into a
+   single XLA program.
+3. **Swap the helper modules** — losses, initializers, inputs, connectivity and
+   plots all move to [`braintools`][braintools] (table below). These are mostly
+   mechanical renames.
+4. **Leave `brainpy.analysis` where it is.** Keep a reduced `brainpy` model
+   alongside the migrated one if you need phase-plane or bifurcation analysis.
+
+### Worked example: an E/I network
+
+The same conductance-based E/I network, before and after. Both versions run
+against the pinned releases and produce comparable firing statistics.
+
+**Before — `brainpy`:**
+
+```python
+import brainpy as bp
+import brainpy.math as bm
+
+bm.set_dt(0.1)
+
+
+class EINet(bp.DynSysGroup):
+    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
+        super().__init__()
+        num = n_exc + n_inh
+        self.n_exc = n_exc
+        self.N = bp.dyn.LifRef(
+            num, V_rest=-60., V_th=-50., V_reset=-60.,
+            tau=20., tau_ref=5.,
+            V_initializer=bp.init.Normal(-55., 2.),
+        )
+        self.delay = bp.VarDelay(self.N.spike, entries={'I': None})
+        self.E = bp.dyn.HalfProjAlignPostMg(
+            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_exc, post=num), weight=0.6),
+            syn=bp.dyn.Expon.desc(size=num, tau=5.),
+            out=bp.dyn.COBA.desc(E=0.),
+            post=self.N,
+        )
+        self.I = bp.dyn.HalfProjAlignPostMg(
+            comm=bp.dnn.EventCSRLinear(bp.conn.FixedProb(prob, pre=n_inh, post=num), weight=6.7),
+            syn=bp.dyn.Expon.desc(size=num, tau=10.),
+            out=bp.dyn.COBA.desc(E=-80.),
+            post=self.N,
+        )
+
+    def update(self, inp=20.):
+        spk = self.delay.at('I')
+        self.E(spk[:self.n_exc])
+        self.I(spk[self.n_exc:])
+        self.delay(self.N(inp))
+        return self.N.spike.value
+
+
+net = EINet()
+runner = bp.DSRunner(net, monitors=['N.spike'])
+runner.run(100.)
+spikes = runner.mon['N.spike']
+```
+
+**After — `brainpy.state`:**
+
+```python
+import brainpy.state
+import brainstate
+import braintools
+import brainunit as u
+
+brainstate.environ.set(dt=0.1 * u.ms)
+
+
+class EINet(brainstate.nn.Module):
+    def __init__(self, n_exc=320, n_inh=80, prob=0.02):
+        super().__init__()
+        num = n_exc + n_inh
+        self.n_exc = n_exc
+        self.N = brainpy.state.LIFRef(
+            num, V_rest=-60. * u.mV, V_th=-50. * u.mV, V_reset=-60. * u.mV,
+            tau=20. * u.ms, tau_ref=5. * u.ms,
+            V_initializer=braintools.init.Normal(-55. * u.mV, 2. * u.mV),
+        )
+        self.E = brainpy.state.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(n_exc, num, prob, 0.6 * u.mS),
+            syn=brainpy.state.Expon.desc(num, tau=5. * u.ms),
+            out=brainpy.state.COBA.desc(E=0. * u.mV),
+            post=self.N,
+        )
+        self.I = brainpy.state.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(n_inh, num, prob, 6.7 * u.mS),
+            syn=brainpy.state.Expon.desc(num, tau=10. * u.ms),
+            out=brainpy.state.COBA.desc(E=-80. * u.mV),
+            post=self.N,
+        )
+
+    def update(self, t, inp):
+        with brainstate.environ.context(t=t):
+            spk = self.N.get_spike() != 0.
+            self.E(spk[:self.n_exc])
+            self.I(spk[self.n_exc:])
+            self.N(inp)
+            return self.N.get_spike()
+
+
+net = EINet()
+brainstate.nn.init_all_states(net)
+
+times = u.math.arange(0. * u.ms, 100. * u.ms, brainstate.environ.get_dt())
+spikes = brainstate.transform.for_loop(lambda t: net.update(t, 20. * u.mA), times)
+```
+
+Four differences carry most of the work: parameters carry units, states are
+initialized explicitly with `init_all_states`, the delay bookkeeping moves into
+the projection instead of an explicit `VarDelay`, and the runner is replaced by a
+compiled `for_loop`.
+
+### Runtime mapping
+
+| `brainpy` | [`brainx`][brainx] |
+| --- | --- |
+| `brainpy.math.Variable` | `brainstate.HiddenState` / `brainstate.ParamState` |
+| `brainpy.DynamicalSystem`, `brainpy.DynSysGroup` | `brainstate.nn.Module` |
+| `brainpy.DSRunner`, `brainpy.LoopOverTime` | `brainstate.transform.for_loop` / `scan` |
+| `brainpy.math.jit` | `brainstate.transform.jit` |
+| `brainpy.math.random` | `brainstate.random` |
+| `brainpy.math.set_dt`, `brainpy.share` | `brainstate.environ` |
+| `brainpy.BPTT` and the trainers | `brainstate.transform` gradients + `braintools.optim` |
+| long rollouts under autograd | `brainstate.transform.checkpointed_for_loop` |
+
+### Module mapping
+
+| `brainpy` | [`brainx`][brainx] |
+| --- | --- |
+| `brainpy.dyn` (point neurons, synapses, projections) | `brainpy.state` |
+| `brainpy.dyn` channels, ions, `CondNeuGroup` | [`braincell`][braincell] |
+| `brainpy.rates`, `brainpy.dyn` rate models | [`brainmass`][brainmass] |
+| `brainpy.dnn`, `brainpy.layers` | `brainstate.nn` |
+| `brainpy.losses`, `brainpy.measure` | `braintools.metric` |
+| `brainpy.initialize` | `braintools.init` |
+| `brainpy.inputs` | `braintools.input` |
+| `brainpy.conn` | `braintools.conn` |
+| `brainpy.optim` | `braintools.optim` |
+| `brainpy.visualization` | `braintools.visualize` |
+| `brainpy.encoding` | `braintools` encoders |
+| `brainpy.math.surrogate` | `braintools.surrogate` |
+| `brainpy.math.sparse`, `.event`, `.jitconn` | [`brainevent`][brainevent] |
+| `brainpy.odeint`, `brainpy.sdeint` | `braintools.quad`, `brainstate.nn.exp_euler_step` |
+| `brainpy.analysis` | *no replacement — see below* |
+
+## What does not carry over
+
+**`brainunit` quantities.** `brainpy` depends on [`brainunit`][brainunit]
+internally, but its array layer does not accept quantities:
+
+```python
+>>> import brainpy.math as bm, brainunit as u
+>>> bm.exp(10. * u.mV)
+TypeError: exp requires ndarray or scalar arguments, got <class 'saiunit.Quantity'> at position 0.
+```
+
+Strip units at the boundary — `(10. * u.mV).to_decimal(u.mV)` — or migrate the
+model. End-to-end unit safety is only available on the [`brainx`][brainx] side.
+
+**Online learning.** [`braintrace`][braintrace] attaches eligibility traces to
+operations inside `brainstate`-based modules. It cannot see a
+`brainpy.math.Variable` graph, so `brainpy` models cannot be trained online
+with it.
+
+**Mixed model trees.** Modules from the two state systems cannot be composed into
+one model. A `brainpy.state` module placed inside a `brainpy.DynSysGroup` never
+gets its states initialized, and fails at run time:
+
+```python
+AttributeError: 'LIF' object has no attribute 'V'
+```
+
+Port whole models, not individual layers. The two can still live in the same
+script as separate models.
+
+**Analysis.** `brainpy.analysis` — phase-plane analyzers, `Bifurcation1D` /
+`Bifurcation2D`, slow-fast decomposition — has no counterpart in
+[`brainx`][brainx]. This is the one capability for which `brainpy` remains the
+right tool. The usual pattern is to keep a reduced `brainpy` model for analysis
+alongside the migrated simulation model.
+
+## Why existing brainpy code still works
+
+The current `brainpy` codebase was reconstructed on top of
+[`brainstate`][brainstate], [`brainevent`][brainevent], and
+[`braintools`][braintools]. This is not only a dependency relationship: many
+internal functions delegate to the production-level implementations, so the two
+share the same underlying code rather than maintaining parallel ports.
 
 - `brainpy.math.surrogate` is an alias of `braintools.surrogate`, and the
   einops-style helpers in `brainpy.math` are re-exported from `brainunit.math`.
-- The sparse and event-driven operators in `brainpy.math.sparse`,
-  `brainpy.math.event`, and `brainpy.math.jitconn` build [`brainevent`][brainevent]
-  structures such as `CSR`, `COO`, and the just-in-time connectivity types,
-  then hand the computation over to them.
-- `brainpy.losses` and `brainpy.measure` delegate to `braintools.metric`,
-  and `brainpy.initialize` delegates to `braintools.init`.
+- The operators in `brainpy.math.sparse`, `brainpy.math.event`, and
+  `brainpy.math.jitconn` build [`brainevent`][brainevent] structures such as
+  `CSR`, `CSC`, and the just-in-time connectivity types, then hand the
+  computation over to them.
+- `brainpy.losses` and `brainpy.measure` delegate to `braintools.metric`, and
+  `brainpy.initialize` delegates to `braintools.init`.
 - `brainpy.inputs` builds its current waveforms from `braintools.input`, and
   `brainpy.visualization` from `braintools.visualize`.
 - State handling, environment settings, and compiled transformations come from
   [`brainstate`][brainstate], through `State`, `environ`, and `transform`.
 
-| package | compatibility |
-| --- | --- |
-| [`brainstate`][brainstate] | compatible |
-| [`brainevent`][brainevent] | compatible |
-| [`braintools`][braintools] | compatible |
-| [`braincell`][braincell] | compatible |
-| [`brainmass`][brainmass] | compatible |
-| [`brainunit`][brainunit] | not compatible |
-| [`braintrace`][braintrace] | not compatible |
+Practically, this means a `brainpy` project keeps working and stays on the same
+foundations as the rest of the ecosystem. It does *not* mean models from both
+sides can be composed:
 
-The [`brainunit`][brainunit] and [`braintrace`][braintrace] exceptions limit how fully a [`brainpy`][brainpy] project
-can participate in the production-level [`brainx`][brainx] ecosystem.
+| package | usable alongside `brainpy` | composable into one `brainpy` model |
+| --- | --- | --- |
+| [`brainstate`][brainstate] | yes — `brainpy` is built on it | — |
+| [`brainevent`][brainevent] | yes — `brainpy` operators delegate to it | — |
+| [`braintools`][braintools] | yes — `brainpy` helpers delegate to it | — |
+| [`braincell`][braincell] | yes, as a separate model | no |
+| [`brainmass`][brainmass] | yes, as a separate model | no |
+| [`brainunit`][brainunit] | only outside `brainpy.math` | no |
+| [`braintrace`][braintrace] | no | no |
 
-## Cellular modeling
+## Where each modeling scale now lives
 
-For biophysical neuron models involving ions, ion channels, compartments, or
-neuronal morphology, migrate completely to [`brainpy.state`][brainpy.state] and [`braincell`][braincell].
+**Point-neuron networks → [`brainpy.state`][brainpy.state].** This was
+`brainpy`'s main strength, and it is the scale that carried over most directly.
+Model names and projection patterns stay recognizable; the state system and the
+runner are what change.
 
-The older ion and channel APIs in [`brainpy`][brainpy] have known design limitations, and
-its compartmental modeling support is restricted to single-compartment models.
-[`braincell`][braincell] provides more comprehensive conductance-based and Hodgkin-Huxley
-models together with morphologically structured, multicompartment cells.
-Mixing the experimental [`brainpy`][brainpy] cell APIs into new [`braincell`][braincell]-based work is
-therefore not recommended.
+**Cells, ions, and morphology → [`braincell`][braincell].** Migrate rather than
+mix. The older ion and channel APIs in `brainpy` have known design limitations
+and its compartmental support is restricted to single-compartment models.
+[`braincell`][braincell] provides comprehensive conductance-based and
+Hodgkin-Huxley models together with morphologically structured, multicompartment
+cells.
 
-## Neural-mass modeling
-
-For neural-mass, whole-brain, and rate-based models, migrate to [`brainmass`][brainmass].
-
-The rate models in [`brainpy`][brainpy] cover FitzHugh-Nagumo, Stuart-Landau,
-threshold-linear, and Wilson-Cowan dynamics. [`brainmass`][brainmass] provides direct
-counterparts for these, together with many models [`brainpy`][brainpy] never had, including
-Jansen-Rit, Epileptor, Hopf, Montbrió-Pazó-Roxin, Wong-Wang, and Larter-Breakspear.
-
-Beyond the models themselves, [`brainmass`][brainmass] adds the infrastructure that
+**Neural-mass and whole-brain models → [`brainmass`][brainmass].** The `brainpy`
+rate models cover FitzHugh-Nagumo, Stuart-Landau, threshold-linear, and
+Wilson-Cowan dynamics. [`brainmass`][brainmass] provides direct counterparts,
+plus models `brainpy` never had — Jansen-Rit, Epileptor, Hopf,
+Montbrió-Pazó-Roxin, Wong-Wang, Larter-Breakspear — and the infrastructure
 whole-brain work needs: explicit coupling schemes, structured noise processes,
 forward models for BOLD, EEG, and MEG signals, and parameter fitting against
-empirical data.
-
-Unlike the cellular case, this is not a warning. The [`brainpy`][brainpy] rate models
-remain usable, and [`brainmass`][brainmass] is compatible with the same foundational
-packages. It is simply that this modeling scale is now developed in
-[`brainmass`][brainmass].
-
-## The remaining brainpy exception: analysis
-
-The analysis module in [`brainpy`][brainpy] is the main capability that does not yet have
-a direct replacement elsewhere in [`brainx`][brainx]. If a workflow depends on this
-module, [`brainpy`][brainpy] may still be the appropriate tool for that part of the
-project.
-
-This is the important exception to the general migration guidance: [`brainx`][brainx]
-covers the modeling and simulation roles of [`brainpy`][brainpy], but its dedicated
-analysis functionality remains unique for now.
-
-## Quick decision guide
-
-| use case | recommended choice |
-| --- | --- |
-| Starting a new point-neuron project | [`brainpy.state`][brainpy.state] |
-| Maintaining an existing [`brainpy`][brainpy] project | Continue with [`brainpy`][brainpy]; migrate for integration |
-| Modeling ions, ion channels, or morphology | [`brainpy.state`][brainpy.state] and [`braincell`][braincell] |
-| Modeling neural-mass or whole-brain dynamics | [`brainmass`][brainmass] |
-| Using [`brainunit`][brainunit] or [`braintrace`][braintrace] | Migrate away from [`brainpy`][brainpy] |
-| Relying on the analysis module in [`brainpy`][brainpy] | Continue using [`brainpy`][brainpy] for analysis |
+empirical data. Unlike the cellular case this is not a warning; the `brainpy`
+rate models still work, this scale is simply developed in
+[`brainmass`][brainmass] now.
 
 ## In short
 
-Treat [`brainpy`][brainpy] as the experimental embryo that inspired the [`brainx`][brainx] ecosystem.
-It remains usable for established projects and its unique analysis tools, but
-[`brainx`][brainx] is the production-level destination for new work. Use [`brainpy.state`][brainpy.state]
-for point-neuron modeling, [`braincell`][braincell] for ions, channels, and morphology, and
+Treat `brainpy` as the experimental embryo that inspired the [`brainx`][brainx]
+ecosystem. It remains maintained and usable for established projects and for its
+unique analysis tools, while [`brainx`][brainx] is where new work belongs:
+[`brainpy.state`][brainpy.state] for point-neuron networks,
+[`braincell`][braincell] for ions, channels, and morphology, and
 [`brainmass`][brainmass] for neural-mass and whole-brain models.
+
+For a hands-on introduction to the target APIs, see the
+[point-neuron network tutorial](./tutorials/brainpy_point_neuron_networks.ipynb).
 
 [brainx]: https://brainx.chaobrain.com/
 [brainpy]: https://brainpy.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,8 +112,8 @@ The tutorials are organized around the BrainX package layers:
    tutorials/brainevent_event-driven.ipynb
    tutorials/braintools_expriment_utilities.ipynb
    tutorials/brainstate_transformations.ipynb
-   tutorials/brainpy.state_point_neuron_networks.ipynb
-   tutorials/brainpy.state_NEST_compatible.ipynb
+   tutorials/brainpy_point_neuron_networks.ipynb
+   tutorials/brainpy_NEST_compatible.ipynb
    tutorials/braincell_HH_neuron.ipynb
    tutorials/braincell_morphological_golgi_cell.ipynb
    tutorials/brainmass_jansenrit_node_simulation.ipynb

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,6 +100,7 @@ The tutorials are organized around the BrainX package layers:
 
    install.md
    brainpy-to-brainx.md
+   brainpy-migration-notes.md
    CHANGELOG.md
 
 

--- a/docs/tutorials/brainpy_NEST_compatible.ipynb
+++ b/docs/tutorials/brainpy_NEST_compatible.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# NEST-compatible point-neuron modeling with ``brainpy.state``\n",
     "\n",
-    "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chaobrain/brainx/blob/main/docs/tutorials/brainpy.state_NEST_compatible.ipynb)\n",
-    "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/chaobrain/brainx/blob/main/docs/tutorials/brainpy.state_NEST_compatible.ipynb)\n",
+    "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chaobrain/brainx/blob/main/docs/tutorials/brainpy_NEST_compatible.ipynb)\n",
+    "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/chaobrain/brainx/blob/main/docs/tutorials/brainpy_NEST_compatible.ipynb)\n",
     "\n",
     "The previous point-neuron tutorial introduced the BrainPy-style route: building networks directly from BrainX objects such as neurons, synapses, projections, inputs, and readouts. This tutorial introduces the other route provided by ``brainpy.state``: [**NEST-compatible models**](https://brainx.chaobrain.com/brainpy-state/nest-style/index.html).\n",
     "\n",

--- a/docs/tutorials/brainpy_point_neuron_networks.ipynb
+++ b/docs/tutorials/brainpy_point_neuron_networks.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# BrainPy-style point-neuron modeling with ``brainpy.state``\n",
     "\n",
-    "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chaobrain/brainx/blob/main/docs/tutorials/brainpy.state_point_neuron_networks.ipynb)\n",
-    "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/chaobrain/brainx/blob/main/docs/tutorials/brainpy.state_point_neuron_networks.ipynb)\n",
+    "[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/chaobrain/brainx/blob/main/docs/tutorials/brainpy_point_neuron_networks.ipynb)\n",
+    "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/chaobrain/brainx/blob/main/docs/tutorials/brainpy_point_neuron_networks.ipynb)\n",
     "\n",
     "## What is `brainpy.state`?\n",
     "``brainpy.state`` is the point-neuron modeling package in the BrainX ecosystem. It is used to build spiking neural systems from stateful neurons, synapses, projections, inputs, and readouts. The package keeps neural dynamics explicit, works with physical units through ``brainunit``, and runs on top of JAX-compatible state transformations from ``brainstate``. \n",


### PR DESCRIPTION
Rework the BrainPy → BrainX documentation into two pages aimed at two different readers.

## Why

`docs/brainpy-to-brainx.md` was a concept page — why `brainpy` exists, how its ideas
became the `brainx` packages, which package owns which modeling scale. It had no code
and no API mapping, so a reader who decided to migrate got no instruction on how.

Adding the mechanics made it a migration guide but buried the conceptual narrative.
Both audiences are real, so they now get a page each.

## What changed

**`docs/brainpy-to-brainx.md`** (same URL) — concept:

- how the packages evolved and relate, restored to the original tone
- status and support: `brainpy` is in maintenance (compatibility and bug fixes; new
  modeling features land in the `brainx` packages)
- where each modeling scale now lives, and why existing `brainpy` code still works
- the migrate-or-stay decision table

**`docs/brainpy-migration-notes.md`** (new) — mechanics:

- `brainpy` vs `brainpy.state`: separate PyPI distributions, different state systems
- migration in four steps, and a worked before/after E/I network
- runtime and module mapping tables
- what does not carry over: `brainunit` quantities inside `brainpy.math`, `braintrace`
  online learning, mixed model trees, `brainpy.analysis`
- the compatibility matrix, split into "usable alongside" and "composable into one model"

Also renames the two `brainpy.state` tutorials to `brainpy_*.ipynb`, updating the
toctree and the notebook badge links.

## Verification

- both code examples executed against the pinned releases (`brainpy` 2.8.1,
  `brainpy-state` 0.1.0, `brainstate` 0.5.2); the classic and `brainpy.state` versions
  of the network produce comparable spike counts
- every symbol named in the mapping tables checked for existence (58/58) — this caught a
  stale reference to `brainevent.COO`, removed in `brainevent` 0.1.0, now `CSC`
- `sphinx-build` exits 0 with no warning from either page; cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split the BrainPy→BrainX documentation into a conceptual guide and a practical migration notes page, and align tutorial notebook names and badges with the new structure.

Enhancements:
- Clarify the relationship between `brainpy` and `brainpy.state`, including their separate distributions, state systems, and recommended usage.
- Refine the migration decision table and short summary to give clearer guidance on when to stay on BrainPy versus move to BrainX.
- Update brainpy.state tutorial notebook filenames and their Colab/Kaggle badge links to match the new naming and doc structure.

Documentation:
- Retarget `docs/brainpy-to-brainx.md` into a concept-focused page explaining package roles, support status, and when to migrate existing BrainPy projects.
- Add `docs/brainpy-migration-notes.md` as a dedicated migration guide covering stepwise porting, runtime and module mappings, incompatibilities, and a worked E/I network example.